### PR TITLE
BUG: increase the pos index in each iteration

### DIFF
--- a/contracts/Enigma.sol
+++ b/contracts/Enigma.sol
@@ -241,6 +241,7 @@ contract Enigma {
         uint pos = 0;
         for (uint i = _start; i < _stop; i++) {
             addresses[pos] = scAddresses[i];
+            pos++;
         }
         return addresses;
     }


### PR DESCRIPTION
The `pos` variable was not incremented inside the loop, causing the array to hold only the last address in its first position. 