### PR TITLE
Remove SolRsaVerify library linkage

### DIFF
--- a/contracts/utils/SolRsaVerify.sol
+++ b/contracts/utils/SolRsaVerify.sol
@@ -84,7 +84,7 @@ library SolRsaVerify {
     function pkcs1Sha256Verify(
         bytes32 _sha256,
         bytes memory _s, bytes memory _e, bytes memory _m
-    ) public view returns (uint) {
+    ) internal view returns (uint) {
         
         uint8[19] memory sha256Prefix = [
             0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
@@ -148,7 +148,7 @@ library SolRsaVerify {
     function pkcs1Sha256VerifyRaw(
         bytes memory _data, 
         bytes memory _s, bytes memory _e, bytes memory _m
-    ) public view returns (uint) {
+    ) internal view returns (uint) {
         return pkcs1Sha256Verify(sha256(_data),_s,_e,_m);
     }
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,7 +9,6 @@ module.exports = function(deployer) {
     return deployer.deploy(SolRsaVerify);
   })
   .then(() => {
-    //deployer.link(SolRsaVerify, Enigma);
     const principal = '0xc44205c3aFf78e99049AfeAE4733a3481575CD26';
     console.log('using account', principal, 'as principal signer');
     return deployer.deploy(Enigma, EnigmaToken.address, principal);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,7 +9,7 @@ module.exports = function(deployer) {
     return deployer.deploy(SolRsaVerify);
   })
   .then(() => {
-    deployer.link(SolRsaVerify, Enigma);
+    //deployer.link(SolRsaVerify, Enigma);
     const principal = '0xc44205c3aFf78e99049AfeAE4733a3481575CD26';
     console.log('using account', principal, 'as principal signer');
     return deployer.deploy(Enigma, EnigmaToken.address, principal);


### PR DESCRIPTION
Public functions in solidity libraries require the linkage of the smart contract with the library, due to the fact that the contract bytecode has to include the address of the deployed library. 
Internal function, however, are embedded (=inlined) within the smart contract, thus no linkage is required.
The two `public` functions of `SolRsaVerify` library were changed to `internal` removing the need for a linkage.
More info can be found [here](https://github.com/ethereum/solidity/issues/3985).
@apalepu23 @fredfortier 