### PR TITLE
Clean unit tests output

### DIFF
--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -584,6 +584,8 @@ describe('Enigma tests', () => {
     it('should fail to create/send deploy contract task using wrapper function because of failed worker encryption ' +
       'key rpc call', async () => {
       server.close(true);
+      const consoleError = console.error; // save original console for future use
+      console.error = jest.fn(); // mock console output to be disregarded, we know the following will error out
       preCode = '9d075ae';
       let scTaskFn = 'deployContract(string,uint)';
       let scTaskArgs = [
@@ -597,6 +599,7 @@ describe('Enigma tests', () => {
           on(eeConstants.DEPLOY_SECRET_CONTRACT_RESULT, (receipt) => resolve(receipt)).
           on(eeConstants.ERROR, (error) => reject(error));
       })).rejects.toEqual({code: -32000, message: 'Network Error'});
+      console.error = consoleError; // restore the original console
       server.listen();
     });
 
@@ -1075,6 +1078,8 @@ describe('Enigma tests', () => {
     it('should fail to create/send compute task using wrapper function because of failed worker encryption ' +
       'key rpc call', async () => {
       server.close(true);
+      const consoleError = console.error; // save original console for future use
+      console.error = jest.fn(); // mock console output to be disregarded, we know the following will error out
       scAddr = scTask.scAddr;
       let taskFn = 'medianWealth(int32,int32)';
       let taskArgs = [
@@ -1088,6 +1093,7 @@ describe('Enigma tests', () => {
           on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result)).
           on(eeConstants.ERROR, (error) => reject(error));
       })).rejects.toEqual({code: -32000, message: 'Network Error'});
+      console.error = consoleError; // restore the original console
       server.listen();
     });
 
@@ -1155,6 +1161,8 @@ describe('Enigma tests', () => {
 
     it('should fail to poll the network because of failed rpc call', async () => {
       server.close(true);
+      const consoleError = console.error; // save original console for future use
+      console.error = jest.fn(); // mock console output to be disregarded, we know the following will error out
       let taskStatuses = [];
       await expect(new Promise((resolve, reject) => {
         enigma.pollTaskInput(task).on(eeConstants.POLL_TASK_INPUT_RESULT, (result) => {
@@ -1164,6 +1172,7 @@ describe('Enigma tests', () => {
           }
         }).on(eeConstants.ERROR, (error) => reject(error));
       })).rejects.toEqual({code: -32000, message: 'Network Error'});
+      console.error = consoleError; // restore the original console
       server.listen();
     });
 


### PR DESCRIPTION
Selectively disabled console output for those tests that we know are erroring out and are cluttering the output. This is accomplished by temporarily mocking `console.error()` with a Jest mock function, and restoring to the original setting after that particular unit test has been run.

Before this PR:
```
> jest

 PASS  test/enigma-utils.spec.js
 PASS  test/Enigma.spec.js (13.385s)
  ● Console

    console.log test/Enigma.spec.js:40
      the accounts [ '0xeA61A5bBd2455A934C4739406F4c69Ba44c6e08A',
        '0xAef56CAE0F095ee2349ca391796Dd99dA0AEdfDa',
        '0x6fca8130873d0CFB9105a78d954DF7aA6649a6B5',
        '0x7f20d943f53Ad88C0d5C59Fd717A3753e993969F',
        '0xaD703949BAF0352a946301dFd7F7Dce56340F351',
        '0x3Bc43BD6674c19c2e32D63D69fC79deACc183FC7',
        '0xd404A3686F8DE80B0a0F02307d56FC96BCEC9e80',
        '0x767aadcA4b49EedD5C94a72Afa011BE0F79118bF',
        '0x05E21f06699E8A6aA86aF1462fDb6449ef8d6B21',
        '0x8829dCD96390052f89FcAa4E030b25814a388281' ]
    console.log test/Enigma.spec.js:41
      [Function: Enigma]
    console.log test/Enigma.spec.js:105
      setting principal node c44205c3aFf78e99049AfeAE4733a3481575CD26
    console.error node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/virtual-console.js:29
      Error: Error: connect ECONNREFUSED 127.0.0.1:3000
          at Object.dispatchError (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:65:19)
          at EventEmitter.client.on.err (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:676:20)
          at EventEmitter.emit (events.js:194:15)
          at Request.preflightClient.on.err (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:412:47)
          at Request.emit (events.js:189:13)
          at Request.onRequestError (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/request/request.js:881:8)
          at ClientRequest.emit (events.js:189:13)
          at Socket.socketErrorListener (_http_client.js:392:9)
          at Socket.emit (events.js:189:13)
          at emitErrorNT (internal/streams/destroy.js:82:8) undefined
    console.error node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/virtual-console.js:29
      Error: Error: connect ECONNREFUSED 127.0.0.1:3000
          at Object.dispatchError (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:65:19)
          at EventEmitter.client.on.err (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:676:20)
          at EventEmitter.emit (events.js:194:15)
          at Request.preflightClient.on.err (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:412:47)
          at Request.emit (events.js:189:13)
          at Request.onRequestError (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/request/request.js:881:8)
          at ClientRequest.emit (events.js:189:13)
          at Socket.socketErrorListener (_http_client.js:392:9)
          at Socket.emit (events.js:189:13)
          at emitErrorNT (internal/streams/destroy.js:82:8) undefined
    console.error node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/virtual-console.js:29
      Error: Error: connect ECONNREFUSED 127.0.0.1:3000
          at Object.dispatchError (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:65:19)
          at EventEmitter.client.on.err (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:676:20)
          at EventEmitter.emit (events.js:194:15)
          at Request.preflightClient.on.err (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:412:47)
          at Request.emit (events.js:189:13)
          at Request.onRequestError (/home/eng-user/enigma-contract-internal/enigma-js/node_modules/request/request.js:881:8)
          at ClientRequest.emit (events.js:189:13)
          at Socket.socketErrorListener (_http_client.js:392:9)
          at Socket.emit (events.js:189:13)
          at emitErrorNT (internal/streams/destroy.js:82:8) undefined

----------------------|----------|----------|----------|----------|-------------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------|----------|----------|----------|----------|-------------------|
All files             |    98.82 |    91.76 |    97.44 |     98.8 |                   |
 src                  |    98.75 |    91.57 |    97.41 |    98.72 |                   |
  Admin.js            |    98.31 |      100 |      100 |    98.31 |               207 |
  Enigma.js           |     98.3 |    85.42 |    95.83 |    98.25 |   140,266,536,577 |
  Server.js           |      100 |      100 |      100 |      100 |                   |
  emitterConstants.js |      100 |      100 |      100 |      100 |                   |
  enigma-utils.js     |      100 |      100 |      100 |      100 |                   |
 src/models           |      100 |      100 |      100 |      100 |                   |
  Task.js             |      100 |      100 |      100 |      100 |                   |
----------------------|----------|----------|----------|----------|-------------------|

Test Suites: 2 passed, 2 total
Tests:       88 passed, 88 total
Snapshots:   0 total
Time:        14.265s, estimated 17s
Ran all test suites.
Done in 30.83s.
```

After this PR:
```
$ jest
 PASS  test/enigma-utils.spec.js
 PASS  test/Enigma.spec.js (14.793s)
  ● Console

    console.log test/Enigma.spec.js:40
      the accounts [ '0xeA61A5bBd2455A934C4739406F4c69Ba44c6e08A',
        '0xAef56CAE0F095ee2349ca391796Dd99dA0AEdfDa',
        '0x6fca8130873d0CFB9105a78d954DF7aA6649a6B5',
        '0x7f20d943f53Ad88C0d5C59Fd717A3753e993969F',
        '0xaD703949BAF0352a946301dFd7F7Dce56340F351',
        '0x3Bc43BD6674c19c2e32D63D69fC79deACc183FC7',
        '0xd404A3686F8DE80B0a0F02307d56FC96BCEC9e80',
        '0x767aadcA4b49EedD5C94a72Afa011BE0F79118bF',
        '0x05E21f06699E8A6aA86aF1462fDb6449ef8d6B21',
        '0x8829dCD96390052f89FcAa4E030b25814a388281' ]
    console.log test/Enigma.spec.js:104
      setting principal node c44205c3aFf78e99049AfeAE4733a3481575CD26

----------------------|----------|----------|----------|----------|-------------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------|----------|----------|----------|----------|-------------------|
All files             |    98.82 |    91.76 |    97.44 |     98.8 |                   |
 src                  |    98.75 |    91.57 |    97.41 |    98.72 |                   |
  Admin.js            |    98.31 |      100 |      100 |    98.31 |               207 |
  Enigma.js           |     98.3 |    85.42 |    95.83 |    98.25 |   140,266,536,577 |
  Server.js           |      100 |      100 |      100 |      100 |                   |
  emitterConstants.js |      100 |      100 |      100 |      100 |                   |
  enigma-utils.js     |      100 |      100 |      100 |      100 |                   |
 src/models           |      100 |      100 |      100 |      100 |                   |
  Task.js             |      100 |      100 |      100 |      100 |                   |
----------------------|----------|----------|----------|----------|-------------------|

Test Suites: 2 passed, 2 total
Tests:       88 passed, 88 total
Snapshots:   0 total
Time:        15.708s, estimated 18s
Ran all test suites.
Done in 16.16s.
```