### PR TITLE
BUG: fixes support for simulation mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ script:
   - truffle compile
   - truffle migrate --reset --network development
   - pushd enigma-js && yarn build && popd
+  - SGX_MODE=SW truffle migrate --reset --network development
+  - SGX_MODE=SW pushd enigma-js && yarn test && popd
 
 after_success:
   - pushd enigma-js && yarn report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - truffle migrate --reset --network development
   - pushd enigma-js && yarn build && popd
   - SGX_MODE=SW truffle migrate --reset --network development
-  - SGX_MODE=SW pushd enigma-js && yarn test && popd
+  - pushd enigma-js && SGX_MODE=SW yarn test && popd
 
 after_success:
   - pushd enigma-js && yarn report-coverage

--- a/contracts/EnigmaSimulation.sol
+++ b/contracts/EnigmaSimulation.sol
@@ -5,7 +5,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
 import "./utils/SolRsaVerify.sol";
 
-import { WorkersImpl } from "./impl/WorkersImpl-Simulation.sol";
+import { WorkersImplSimulation } from "./impl/WorkersImplSimulation.sol";
 import { PrincipalImpl } from "./impl/PrincipalImpl.sol";
 import { TaskImpl } from "./impl/TaskImpl.sol";
 import { SecretContractImpl } from "./impl/SecretContractImpl.sol";
@@ -16,7 +16,7 @@ import { EnigmaStorage } from "./impl/EnigmaStorage.sol";
 import { Getters } from "./impl/Getters.sol";
 import { ERC20 } from "./interfaces/ERC20.sol";
 
-contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
+contract EnigmaSimulation is EnigmaStorage, EnigmaEvents, Getters {
     using SafeMath for uint256;
     using ECDSA for bytes32;
 
@@ -87,7 +87,7 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     modifier canWithdraw(address _user) {
         EnigmaCommon.Worker memory worker = state.workers[_user];
         require(worker.status == EnigmaCommon.WorkerStatus.LoggedOut, "Worker not registered or not logged out");
-        EnigmaCommon.WorkerLog memory workerLog = WorkersImpl.getLatestWorkerLogImpl(state, worker, block.number);
+        EnigmaCommon.WorkerLog memory workerLog = WorkersImplSimulation.getLatestWorkerLogImpl(state, worker, block.number);
         require(workerLog.workerEventType == EnigmaCommon.WorkerLogType.LogOut,
             "Worker's last log is not of LogOut type");
         require(getFirstBlockNumber(block.number) > workerLog.blockNumber,
@@ -139,7 +139,7 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     function register(address _signer, bytes memory _report, bytes memory _signature)
     public
     {
-        WorkersImpl.registerImpl(state, _signer, _report, _signature);
+        WorkersImplSimulation.registerImpl(state, _signer, _report, _signature);
     }
 //
     /**
@@ -152,7 +152,7 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     public
     workerRegistered(_custodian)
     {
-        WorkersImpl.depositImpl(state, _custodian, _amount);
+        WorkersImplSimulation.depositImpl(state, _custodian, _amount);
     }
 
     /**
@@ -165,7 +165,7 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     public
     canWithdraw(_custodian)
     {
-        WorkersImpl.withdrawImpl(state, _custodian, _amount);
+        WorkersImplSimulation.withdrawImpl(state, _custodian, _amount);
     }
 
     /**
@@ -173,14 +173,14 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     * selection process.
     */
     function login() public canLogIn(msg.sender) {
-        WorkersImpl.loginImpl(state);
+        WorkersImplSimulation.loginImpl(state);
     }
 
     /**
     * Logout worker. Worker must be logged in to do so.
     */
     function logout() public workerLoggedIn(msg.sender) {
-        WorkersImpl.logoutImpl(state);
+        WorkersImplSimulation.logoutImpl(state);
     }
 
     /**
@@ -477,14 +477,14 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     public
     view
     returns (uint) {
-        return WorkersImpl.getFirstBlockNumberImpl(state, _blockNumber);
+        return WorkersImplSimulation.getFirstBlockNumberImpl(state, _blockNumber);
     }
 
     function getWorkerParams(uint _blockNumber)
     public
     view
     returns (uint, uint, address[] memory, uint[] memory) {
-        return WorkersImpl.getWorkerParamsImpl(state, _blockNumber);
+        return WorkersImplSimulation.getWorkerParamsImpl(state, _blockNumber);
     }
 
     /**
@@ -500,7 +500,7 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     view
     returns (address[] memory)
     {
-        return WorkersImpl.getWorkerGroupImpl(state, _blockNumber, _scAddr);
+        return WorkersImplSimulation.getWorkerGroupImpl(state, _blockNumber, _scAddr);
     }
 
     /**
@@ -514,7 +514,7 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     workerRegistered(_custodian)
     returns (address, bytes memory)
     {
-        return WorkersImpl.getReportImpl(state, _custodian);
+        return WorkersImplSimulation.getReportImpl(state, _custodian);
     }
 
     /**
@@ -527,6 +527,6 @@ contract Enigma is EnigmaStorage, EnigmaEvents, Getters {
     view
     returns (uint)
     {
-        return WorkersImpl.verifyReportImpl(_data, _signature);
+        return WorkersImplSimulation.verifyReportImpl(_data, _signature);
     }
 }

--- a/contracts/impl/PrincipalImplSimulation.sol
+++ b/contracts/impl/PrincipalImplSimulation.sol
@@ -1,0 +1,104 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
+
+import { EnigmaCommon } from "./EnigmaCommon.sol";
+import { EnigmaState } from "./EnigmaState.sol";
+import { WorkersImplSimulation } from "./WorkersImplSimulation.sol";
+
+/**
+ * @author Enigma
+ *
+ * Library that maintains functionality associated with Principal node
+ */
+library PrincipalImpl {
+    using SafeMath for uint256;
+    using ECDSA for bytes32;
+
+    event WorkersParameterized(uint seed, uint256 firstBlockNumber, uint256 inclusionBlockNumber, address[] workers,
+        uint[] stakes, uint nonce);
+
+    function setWorkersParamsImpl(EnigmaState.State storage state, uint _blockNumber, uint _seed, bytes memory _sig)
+    public
+    {
+        // Reparameterizing workers with a new seed
+        // This should be called for each epoch by the Principal node
+
+        // We assume that the Principal is always the first registered node
+        require(state.workers[msg.sender].signer == state.principal, "Only the Principal can update the seed");
+        require(_blockNumber - WorkersImplSimulation.getFirstBlockNumberImpl(state, _blockNumber) >= state.epochSize,
+            "Already called during this epoch");
+
+        // Create a new workers parameters item for the specified seed.
+        // The workers parameters list is a sort of cache, it never grows beyond its limit.
+        // If the list is full, the new item will replace the item assigned to the lowest block number.
+        uint paramIndex = 0;
+        for (uint pi = 0; pi < state.workersParams.length; pi++) {
+            // Find an empty slot in the array, if full use the lowest block number
+            if (state.workersParams[pi].firstBlockNumber == 0) {
+                paramIndex = pi;
+                break;
+            } else if (state.workersParams[pi].firstBlockNumber < state.workersParams[paramIndex].firstBlockNumber) {
+                paramIndex = pi;
+            }
+        }
+        EnigmaCommon.WorkersParams storage workerParams = state.workersParams[paramIndex];
+        workerParams.firstBlockNumber = block.number;
+        workerParams.seed = _seed;
+
+        (workerParams.workers, workerParams.stakes) = getActiveWorkersImpl(state, _blockNumber);
+
+        // Check worker's signature
+        bytes32 msgHash = keccak256(abi.encode(_seed, state.userTaskDeployments[msg.sender], workerParams.workers,
+            workerParams.stakes));
+//        require(msgHash.recover(_sig) == state.principal, "Invalid signature");
+
+        for (uint wi = 0; wi < workerParams.workers.length; wi++) {
+            EnigmaCommon.Worker storage worker = state.workers[workerParams.workers[wi]];
+            worker.workerLogs.push(EnigmaCommon.WorkerLog({
+                workerEventType: EnigmaCommon.WorkerLogType.Compound,
+                blockNumber: block.number,
+                balance: worker.balance
+            }));
+        }
+
+        emit WorkersParameterized(_seed, block.number, _blockNumber, workerParams.workers,
+            workerParams.stakes, state.userTaskDeployments[msg.sender]);
+        state.userTaskDeployments[msg.sender]++;
+    }
+
+    function getActiveWorkersImpl(EnigmaState.State storage state, uint _blockNumber)
+    public
+    view
+    returns (address[] memory, uint[] memory)
+    {
+        uint maxLength = state.workerAddresses.length;
+        address[] memory activeWorkerAddressesFull = new address[](maxLength);
+        uint[] memory activeWorkerStakesFull = new uint[](maxLength);
+        uint filteredCount;
+
+        for (uint i = 0; i < maxLength; i++) {
+            EnigmaCommon.Worker memory worker = state.workers[state.workerAddresses[i]];
+            EnigmaCommon.WorkerLog memory workerLog = WorkersImplSimulation.getLatestWorkerLogImpl(state, worker, _blockNumber);
+            if (((workerLog.workerEventType == EnigmaCommon.WorkerLogType.LogIn) ||
+                (workerLog.workerEventType == EnigmaCommon.WorkerLogType.Compound)) &&
+                worker.signer != state.principal)
+            {
+                activeWorkerAddressesFull[filteredCount] = state.workerAddresses[i];
+                activeWorkerStakesFull[filteredCount] = workerLog.balance;
+                filteredCount++;
+            }
+        }
+
+        address[] memory activeWorkerAddresses = new address[](filteredCount);
+        uint[] memory activeWorkerStakes = new uint[](filteredCount);
+        for (uint ic = 0; ic < filteredCount; ic++) {
+            activeWorkerAddresses[ic] = activeWorkerAddressesFull[ic];
+            activeWorkerStakes[ic] = activeWorkerStakesFull[ic];
+        }
+
+        return (activeWorkerAddresses, activeWorkerStakes);
+    }
+}

--- a/contracts/impl/PrincipalImplSimulation.sol
+++ b/contracts/impl/PrincipalImplSimulation.sol
@@ -13,7 +13,7 @@ import { WorkersImplSimulation } from "./WorkersImplSimulation.sol";
  *
  * Library that maintains functionality associated with Principal node
  */
-library PrincipalImpl {
+library PrincipalImplSimulation {
     using SafeMath for uint256;
     using ECDSA for bytes32;
 

--- a/contracts/impl/TaskImplSimulation.sol
+++ b/contracts/impl/TaskImplSimulation.sol
@@ -14,7 +14,7 @@ import "../utils/SolRsaVerify.sol";
  *
  * Library that maintains functionality associated with tasks
  */
-library TaskImpl {
+library TaskImplSimulation {
     using SafeMath for uint256;
     using ECDSA for bytes32;
 
@@ -133,7 +133,7 @@ library TaskImpl {
             uint64(_optionalEthereumData.length), _optionalEthereumData,
             uint64(20), _optionalEthereumContractAddress,
             bytes1(0x01)));
-        // require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+        require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
         // Set the secret contract's attributes in registry
         EnigmaCommon.SecretContract storage secretContract = state.contracts[_taskId];
@@ -289,7 +289,7 @@ library TaskImpl {
             uint64(20), _optionalEthereumContractAddress,
             bytes1(0x01)));
 
-        // require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+        require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
 
         if (_optionalEthereumContractAddress != address(0)) {
             (bool success,) = _optionalEthereumContractAddress.call(_optionalEthereumData);

--- a/contracts/impl/TaskImplSimulation.sol
+++ b/contracts/impl/TaskImplSimulation.sol
@@ -1,0 +1,389 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
+
+import { EnigmaCommon } from "./EnigmaCommon.sol";
+import { EnigmaState } from "./EnigmaState.sol";
+import { WorkersImplSimulation } from "./WorkersImplSimulation.sol";
+import "../utils/SolRsaVerify.sol";
+
+/**
+ * @author Enigma
+ *
+ * Library that maintains functionality associated with tasks
+ */
+library TaskImpl {
+    using SafeMath for uint256;
+    using ECDSA for bytes32;
+
+    event TaskRecordCreated(bytes32 taskId, bytes32 inputsHash, uint gasLimit, uint gasPx, address sender,
+        uint blockNumber);
+    event TaskRecordsCreated(bytes32[] taskIds, bytes32[] inputsHashes, uint[] gasLimits, uint[] gasPxs, address sender,
+        uint blockNumber);
+    event SecretContractDeployed(bytes32 scAddr, bytes32 codeHash, bytes32 initStateDeltaHash);
+    event ReceiptVerified(bytes32 taskId, bytes32 stateDeltaHash, bytes32 outputHash, bytes optionalEthereumData,
+        address optionalEthereumContractAddress, bytes sig);
+    event ReceiptsVerified(bytes32[] taskIds, bytes32[] stateDeltaHashes, bytes32[] outputHashes,
+        bytes _optionalEthereumData, address optionalEthereumContractAddress, bytes sig);
+    event ReceiptFailed(bytes32 taskId, bytes sig);
+
+    function createDeploymentTaskRecordImpl(
+        EnigmaState.State storage state,
+        bytes32 _inputsHash,
+        uint _gasLimit,
+        uint _gasPx,
+        uint _firstBlockNumber,
+        uint _nonce
+    )
+    public
+    {
+        // Check that the locally-generated nonce matches the on-chain value, otherwise _scAddr is invalid
+        require(state.userTaskDeployments[msg.sender] == _nonce, "Incorrect nonce yielding bad secret contract address");
+
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(_firstBlockNumber == WorkersImplSimulation.getFirstBlockNumberImpl(state, block.number), "Wrong epoch for this task");
+
+        // Transfer fee from sender to contract
+        uint fee = _gasLimit.mul(_gasPx);
+        require(state.engToken.allowance(msg.sender, address(this)) >= fee, "Allowance not enough");
+        require(state.engToken.transferFrom(msg.sender, address(this), fee), "Transfer not valid");
+
+        // Create taskId and TaskRecord
+        bytes32 taskId = keccak256(abi.encodePacked(msg.sender, state.userTaskDeployments[msg.sender]));
+        EnigmaCommon.TaskRecord storage task = state.tasks[taskId];
+        require(task.sender == address(0), "Task already exists");
+        task.inputsHash = _inputsHash;
+        task.gasLimit = _gasLimit;
+        task.gasPx = _gasPx;
+        task.sender = msg.sender;
+        task.blockNumber = block.number;
+        task.status = EnigmaCommon.TaskStatus.RecordCreated;
+
+        // Increment user task deployment nonce
+        state.userTaskDeployments[msg.sender]++;
+
+        emit TaskRecordCreated(taskId, _inputsHash, _gasLimit, _gasPx, msg.sender, block.number);
+    }
+
+    function deploySecretContractFailureImpl(EnigmaState.State storage state, bytes32 _taskId, uint _gasUsed,
+        bytes memory _sig)
+    public
+    {
+        EnigmaCommon.TaskRecord storage task = state.tasks[_taskId];
+        require(task.status == EnigmaCommon.TaskStatus.RecordCreated, 'Invalid task status');
+
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(msg.sender == WorkersImplSimulation.getWorkerGroupImpl(state, task.blockNumber, _taskId)[0],
+            "Not the selected worker for this task");
+
+        // Check that worker isn't charging the user too high of a fee
+        require(task.gasLimit >= _gasUsed, "Too much gas used for task");
+
+        // Update proof and status attributes of TaskRecord
+        task.proof = _sig;
+        task.status = EnigmaCommon.TaskStatus.ReceiptFailed;
+
+        transferFundsAfterTask(state, msg.sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
+
+        // Verify the worker's signature
+        bytes32 msgHash = keccak256(abi.encodePacked(task.inputsHash,
+            _gasUsed,
+            bytes1(0x00)));
+        require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+
+        emit ReceiptFailed(_taskId, _sig);
+    }
+
+    function verifyDeployReceipt(EnigmaState.State storage state, bytes32 _taskId, uint _gasUsed, address _sender,
+        bytes memory _sig)
+    internal
+    {
+        EnigmaCommon.TaskRecord storage task = state.tasks[_taskId];
+        require(task.status == EnigmaCommon.TaskStatus.RecordCreated, 'Invalid task status');
+
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(_sender == WorkersImplSimulation.getWorkerGroupImpl(state, task.blockNumber, _taskId)[0],
+            "Not the selected worker for this task");
+
+        // Check that worker isn't charging the user too high of a fee
+        require(task.gasLimit >= _gasUsed, "Too much gas used for task");
+
+        // Update proof and status attributes of TaskRecord
+        task.proof = _sig;
+        task.status = EnigmaCommon.TaskStatus.ReceiptVerified;
+
+        transferFundsAfterTask(state, _sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
+    }
+
+    function deploySecretContractImpl(EnigmaState.State storage state, bytes32 _taskId, bytes32 _preCodeHash,
+        bytes32 _codeHash, bytes32 _initStateDeltaHash, bytes memory _optionalEthereumData,
+        address _optionalEthereumContractAddress, uint _gasUsed, bytes memory _sig)
+    public
+    {
+        verifyDeployReceipt(state, _taskId, _gasUsed, msg.sender, _sig);
+        EnigmaCommon.TaskRecord memory task = state.tasks[_taskId];
+
+        // Verify the worker's signature
+        bytes32 msgHash = keccak256(abi.encodePacked(task.inputsHash,
+            _codeHash,
+            _initStateDeltaHash,
+            _gasUsed,
+            uint64(_optionalEthereumData.length), _optionalEthereumData,
+            uint64(20), _optionalEthereumContractAddress,
+            bytes1(0x01)));
+        // require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+
+        // Set the secret contract's attributes in registry
+        EnigmaCommon.SecretContract storage secretContract = state.contracts[_taskId];
+        secretContract.owner = task.sender;
+        secretContract.preCodeHash = _preCodeHash;
+        secretContract.codeHash = _codeHash;
+        secretContract.status = EnigmaCommon.SecretContractStatus.Deployed;
+        secretContract.stateDeltaHashes.push(_initStateDeltaHash);
+        state.scAddresses.push(_taskId);
+
+        if (_optionalEthereumContractAddress != address(0)) {
+            (bool success,) = _optionalEthereumContractAddress.call(_optionalEthereumData);
+            require(success, "Ethereum call failed");
+        }
+
+        emit SecretContractDeployed(_taskId, _codeHash, _initStateDeltaHash);
+    }
+
+    function transferFundsAfterTask(EnigmaState.State storage state, address _worker, address _user, uint _gasUsed,
+        uint _gasUnused, uint _gasPx)
+    internal {
+        // Credit worker with the fees associated with this task
+        state.workers[_worker].balance = state.workers[_worker].balance.add(_gasUsed.mul(_gasPx));
+
+        // Credit the task sender with the unused gas fees
+        require(state.engToken.transfer(_user, (_gasUnused).mul(_gasPx)),
+            "Token transfer failed");
+    }
+
+    function createTaskRecordImpl(
+        EnigmaState.State storage state,
+        bytes32 _inputsHash,
+        uint _gasLimit,
+        uint _gasPx,
+        uint _firstBlockNumber
+    )
+    public
+    {
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(_firstBlockNumber == WorkersImplSimulation.getFirstBlockNumberImpl(state, block.number), "Wrong epoch for this task");
+
+        // Transfer fee from sender to contract
+        uint fee = _gasLimit.mul(_gasPx);
+        require(state.engToken.allowance(msg.sender, address(this)) >= fee, "Allowance not enough");
+        require(state.engToken.transferFrom(msg.sender, address(this), fee), "Transfer not valid");
+
+        // Create taskId and TaskRecord
+        bytes32 taskId = keccak256(abi.encodePacked(msg.sender, state.userTaskDeployments[msg.sender]));
+        EnigmaCommon.TaskRecord storage task = state.tasks[taskId];
+        require(task.sender == address(0), "Task already exists");
+        task.inputsHash = _inputsHash;
+        task.gasLimit = _gasLimit;
+        task.gasPx = _gasPx;
+        task.sender = msg.sender;
+        task.blockNumber = block.number;
+        task.status = EnigmaCommon.TaskStatus.RecordCreated;
+
+        // Increment user task deployment nonce
+        state.userTaskDeployments[msg.sender]++;
+
+        emit TaskRecordCreated(taskId, _inputsHash, _gasLimit, _gasPx, msg.sender, block.number);
+    }
+
+    function commitTaskFailureImpl(
+        EnigmaState.State storage state,
+        bytes32 _scAddr,
+        bytes32 _taskId,
+        uint _gasUsed,
+        bytes memory _sig
+    )
+    public
+    {
+        EnigmaCommon.SecretContract memory secretContract = state.contracts[_scAddr];
+
+        EnigmaCommon.TaskRecord storage task = state.tasks[_taskId];
+        require(task.status == EnigmaCommon.TaskStatus.RecordCreated, 'Invalid task status');
+
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(msg.sender == WorkersImplSimulation.getWorkerGroupImpl(state, task.blockNumber, _scAddr)[0],
+            "Not the selected worker for this task");
+
+        // Check that worker isn't charging the user too high of a fee
+        require(task.gasLimit >= _gasUsed, "Too much gas used for task");
+
+        // Update proof and status attributes of TaskRecord
+        task.proof = _sig;
+        task.status = EnigmaCommon.TaskStatus.ReceiptFailed;
+
+        transferFundsAfterTask(state, msg.sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
+
+        // Verify the worker's signature
+        bytes32 msgHash = keccak256(abi.encodePacked(task.inputsHash,
+            secretContract.codeHash,
+            _gasUsed,
+            bytes1(0x00)));
+        require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+
+        emit ReceiptFailed(_taskId, _sig);
+    }
+
+    function verifyReceipt(EnigmaState.State storage state, bytes32 _scAddr, bytes32 _taskId, bytes32 _stateDeltaHash, uint _gasUsed, address _sender,
+        bytes memory _sig)
+    internal
+    {
+        EnigmaCommon.TaskRecord storage task = state.tasks[_taskId];
+        require(task.status == EnigmaCommon.TaskStatus.RecordCreated, 'Invalid task status');
+
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(_sender == WorkersImplSimulation.getWorkerGroupImpl(state, task.blockNumber, _scAddr)[0], "Not the selected worker for this task");
+
+        // Check that worker isn't charging the user too high of a fee
+        require(task.gasLimit >= _gasUsed, "Too much gas used for task");
+
+        // Update proof and status attributes of TaskRecord
+        task.proof = _sig;
+        task.status = EnigmaCommon.TaskStatus.ReceiptVerified;
+
+        transferFundsAfterTask(state, _sender, task.sender, _gasUsed, task.gasLimit.sub(_gasUsed), task.gasPx);
+    }
+
+    function commitReceiptImpl(
+        EnigmaState.State storage state,
+        bytes32 _scAddr,
+        bytes32 _taskId,
+        bytes32 _stateDeltaHash,
+        bytes32 _outputHash,
+        bytes memory _optionalEthereumData,
+        address _optionalEthereumContractAddress,
+        uint _gasUsed,
+        bytes memory _sig
+    )
+    public
+    {
+        EnigmaCommon.SecretContract storage secretContract = state.contracts[_scAddr];
+        // Obtain the last state delta hash the contract is aware of
+        bytes32 lastStateDeltaHash = secretContract.stateDeltaHashes[secretContract.stateDeltaHashes.length - 1];
+
+        // Verify the receipt
+        verifyReceipt(state, _scAddr, _taskId, _stateDeltaHash, _gasUsed, msg.sender, _sig);
+
+        // Append the new state delta hash and set the contract's output hash
+        secretContract.stateDeltaHashes.push(_stateDeltaHash);
+        secretContract.outputHashes.push(_outputHash);
+
+        // Verify the worker's signature
+        bytes32 msgHash = keccak256(abi.encodePacked(secretContract.codeHash,
+            state.tasks[_taskId].inputsHash,
+            lastStateDeltaHash,
+            _stateDeltaHash,
+            _outputHash,
+            _gasUsed,
+            uint64(_optionalEthereumData.length), _optionalEthereumData,
+            uint64(20), _optionalEthereumContractAddress,
+            bytes1(0x01)));
+
+        // require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+
+        if (_optionalEthereumContractAddress != address(0)) {
+            (bool success,) = _optionalEthereumContractAddress.call(_optionalEthereumData);
+            require(success, "Ethereum call failed");
+        }
+
+        emit ReceiptVerified(_taskId, _stateDeltaHash, _outputHash, _optionalEthereumData,
+            _optionalEthereumContractAddress, _sig);
+    }
+
+    function createTaskRecordsImpl(
+        EnigmaState.State storage state,
+        bytes32[] memory _inputsHashes,
+        uint[] memory _gasLimits,
+        uint[] memory _gasPxs,
+        uint _firstBlockNumber
+    )
+    public
+    {
+        // Worker deploying task must be the appropriate worker as per the worker selection algorithm
+        require(_firstBlockNumber == WorkersImplSimulation.getFirstBlockNumberImpl(state, block.number), "Wrong epoch for this task");
+
+        bytes32[] memory taskIds = new bytes32[](_inputsHashes.length);
+        for (uint i = 0; i < _inputsHashes.length; i++) {
+            // Transfer fee from sender to contract
+            uint fee = _gasLimits[i].mul(_gasPxs[i]);
+            require(state.engToken.allowance(msg.sender, address(this)) >= fee, "Allowance not enough");
+            require(state.engToken.transferFrom(msg.sender, address(this), fee), "Transfer not valid");
+
+            // Create taskId and TaskRecord
+            bytes32 taskId = keccak256(abi.encodePacked(msg.sender, state.userTaskDeployments[msg.sender]));
+            EnigmaCommon.TaskRecord storage task = state.tasks[taskId];
+            require(task.sender == address(0), "Task already exists");
+            taskIds[i] = taskId;
+            task.inputsHash = _inputsHashes[i];
+            task.gasLimit = _gasLimits[i];
+            task.gasPx = _gasPxs[i];
+            task.sender = msg.sender;
+            task.blockNumber = block.number;
+            task.status = EnigmaCommon.TaskStatus.RecordCreated;
+
+            // Increment user task deployment nonce
+            state.userTaskDeployments[msg.sender]++;
+        }
+        emit TaskRecordsCreated(taskIds, _inputsHashes, _gasLimits, _gasPxs, msg.sender, block.number);
+    }
+
+    function commitReceiptsImpl(
+        EnigmaState.State storage state,
+        bytes32 _scAddr,
+        bytes32[] memory _taskIds,
+        bytes32[] memory _stateDeltaHashes,
+        bytes32[] memory _outputHashes,
+        bytes memory _optionalEthereumData,
+        address _optionalEthereumContractAddress,
+        uint[] memory _gasesUsed,
+        bytes memory _sig
+    )
+    public
+    {
+        bytes32[] memory inputsHashes = new bytes32[](_taskIds.length);
+        EnigmaCommon.SecretContract storage secretContract = state.contracts[_scAddr];
+        // Obtain the last state delta hash the contract is aware of
+        bytes32 lastStateDeltaHash = secretContract.stateDeltaHashes[secretContract.stateDeltaHashes.length - 1];
+
+        for (uint i = 0; i < _taskIds.length; i++) {
+            // Verify the receipt
+            verifyReceipt(state, _scAddr, _taskIds[i], _stateDeltaHashes[i], _gasesUsed[i], msg.sender, _sig);
+            inputsHashes[i] = state.tasks[_taskIds[i]].inputsHash;
+
+            // Append the new state delta hash
+            secretContract.stateDeltaHashes.push(_stateDeltaHashes[i]);
+            secretContract.outputHashes.push(_outputHashes[i]);
+        }
+
+        // Verify the worker's signature
+        bytes32 msgHash = keccak256(abi.encodePacked(secretContract.codeHash,
+            inputsHashes,
+            lastStateDeltaHash,
+            _stateDeltaHashes,
+            _outputHashes,
+            _gasesUsed,
+            uint64(_optionalEthereumData.length), _optionalEthereumData,
+            uint64(20), _optionalEthereumContractAddress,
+            bytes1(0x01)));
+
+        require(msgHash.recover(_sig) == state.workers[msg.sender].signer, "Invalid signature");
+
+        if (_optionalEthereumContractAddress != address(0)) {
+            (bool success,) = _optionalEthereumContractAddress.call(_optionalEthereumData);
+            require(success, "Ethereum call failed");
+        }
+
+        emit ReceiptsVerified(_taskIds, _stateDeltaHashes, _outputHashes, _optionalEthereumData,
+            _optionalEthereumContractAddress, _sig);
+    }
+}

--- a/contracts/impl/WorkersImplSimulation.sol
+++ b/contracts/impl/WorkersImplSimulation.sol
@@ -13,7 +13,7 @@ import "../utils/Base64.sol";
  *
  * Library that maintains functionality associated with workers
  */
-library WorkersImpl {
+library WorkersImplSimulation {
     using SafeMath for uint256;
 
     event Registered(address custodian, address signer);

--- a/enigma-js/test/Enigma.spec.js
+++ b/enigma-js/test/Enigma.spec.js
@@ -1,15 +1,19 @@
 /* eslint-disable require-jsdoc */
+import dotenv from 'dotenv';
 import Enigma from '../src/Enigma';
 import utils from '../src/enigma-utils';
 import forge from 'node-forge';
 import Web3 from 'web3';
 import EthCrypto from 'eth-crypto';
 import EnigmaContract from '../../build/contracts/Enigma';
+import EnigmaContractSimulation from '../../build/contracts/EnigmaSimulation';
 import EnigmaTokenContract from '../../build/contracts/EnigmaToken';
 import data from './data';
 import * as eeConstants from '../src/emitterConstants';
 import SampleContract from '../../build/contracts/Sample';
 import {execInContainer} from './principal-utils';
+
+dotenv.config();
 
 // Launch local mock JSON RPC Server
 import RPCServer from '../src/Server';
@@ -40,7 +44,9 @@ describe('Enigma tests', () => {
         console.log('the accounts', accounts);
         enigma = new Enigma(
           web3,
-          EnigmaContract.networks['4447'].address,
+          (typeof process.env.SGX_MODE !== 'undefined' && process.env.SGX_MODE == 'SW') ?
+            EnigmaContractSimulation.networks['4447'].address :
+            EnigmaContract.networks['4447'].address,
           EnigmaTokenContract.networks['4447'].address,
           'http://localhost:3000',
           {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -14,10 +14,10 @@ const EPOCH_SIZE = 10;
 dotenv.config();    // Reads .env configuration file, if present
 
 const Enigma = (typeof process.env.SGX_MODE !== 'undefined' && process.env.SGX_MODE == 'SW') ?
-  artifacts.require('Enigma-Simulation.sol') :
+  artifacts.require('EnigmaSimulation.sol') :
   artifacts.require('Enigma.sol');
 const WorkersImpl = (typeof process.env.SGX_MODE !== 'undefined' && process.env.SGX_MODE == 'SW') ?
-  artifacts.require('./impl/WorkersImpl-Simulation.sol') :
+  artifacts.require('./impl/WorkersImplSimulation.sol') :
   artifacts.require('./impl/WorkersImpl.sol');
 
 async function deployProtocol(deployer) {
@@ -29,8 +29,12 @@ async function deployProtocol(deployer) {
   ]);
 
   await Promise.all([
-    TaskImpl.link('WorkersImpl', WorkersImpl.address),
-    PrincipalImpl.link('WorkersImpl', WorkersImpl.address),
+    (typeof process.env.SGX_MODE !== 'undefined' && process.env.SGX_MODE == 'SW') ?
+      TaskImpl.link('WorkersImplSimulation', WorkersImpl.address):
+      TaskImpl.link('WorkersImpl', WorkersImpl.address),
+    (typeof process.env.SGX_MODE !== 'undefined' && process.env.SGX_MODE == 'SW') ?
+      PrincipalImpl.link('WorkersImplSimulation', WorkersImpl.address) :
+      PrincipalImpl.link('WorkersImpl', WorkersImpl.address),
   ]);
   await Promise.all([
     deployer.deploy(TaskImpl),
@@ -38,7 +42,9 @@ async function deployProtocol(deployer) {
   ]);
 
   await Promise.all([
-    Enigma.link('WorkersImpl', WorkersImpl.address),
+    (typeof process.env.SGX_MODE !== 'undefined' && process.env.SGX_MODE == 'SW') ?
+      Enigma.link('WorkersImplSimulation', WorkersImpl.address) :
+      Enigma.link('WorkersImpl', WorkersImpl.address),
     Enigma.link('PrincipalImpl', PrincipalImpl.address),
     Enigma.link('TaskImpl', TaskImpl.address),
     Enigma.link('SecretContractImpl', SecretContractImpl.address),

--- a/scripts/checkSimulationContracts.bash
+++ b/scripts/checkSimulationContracts.bash
@@ -13,36 +13,81 @@ pushd $SELFDIR > /dev/null 2>&1
 CONTRACTSDIR='../contracts';
 IMPLDIR="$CONTRACTSDIR/impl";
 
-# Replace the one line that needs to be replaced in Enigma.sol to support Simulation
-sed -e "s#import { WorkersImpl } from \"./impl/WorkersImpl.sol\";#import { WorkersImpl } from \"./impl/WorkersImpl-Simulation.sol\";#" $CONTRACTSDIR/Enigma.sol > Enigma-Simulation.sol
+# Replace what needs to be replaced in Enigma.sol to support Simulation
+sed -e "s#import { WorkersImpl } from \"./impl/WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./impl/WorkersImplSimulation.sol\";#" $CONTRACTSDIR/Enigma.sol > EnigmaSimulation.sol
+sed -i "s/contract Enigma is/contract EnigmaSimulation is/" EnigmaSimulation.sol
+sed -i "s/WorkersImpl\./WorkersImplSimulation./g" EnigmaSimulation.sol
 
-# Check if the existing Enigma-Simulation.sol matches this one-line substitution
-if ! diff Enigma-Simulation.sol $CONTRACTSDIR/Enigma-Simulation.sol > /dev/null 2>&1; then
+# Check if the existing EnigmaSimulation.sol matches the replacement version
+if ! diff EnigmaSimulation.sol $CONTRACTSDIR/EnigmaSimulation.sol > /dev/null 2>&1; then
 	if [ $FIX = 1 ]; then
-		mv Enigma-Simulation.sol $CONTRACTSDIR/Enigma-Simulation.sol
+		mv EnigmaSimulation.sol $CONTRACTSDIR/EnigmaSimulation.sol
 	else 
-		echo "Error: Enigma.sol and Enigma-Simulation.sol differ more than they should."; 
+		echo "Error: Enigma.sol and EnigmaSimulation.sol differ more than they should.";
 		echo "Run this script with --fix to fix the differences automatically."
-		rm -f Enigma-Simulation.sol
+		rm -f EnigmaSimulation.sol
 		popd > /dev/null 2>&1
 		exit 1;
 	fi
+else
+	rm -f EnigmaSimulation.sol
 fi
 
 # Comment out a block to support Simulation Mode in WorkersImpl.sol
-sed -e '/require(verifyReportImpl/,/require(signerQuote/ s_^_//_' $IMPLDIR/WorkersImpl.sol > WorkersImpl-Simulation.sol
+sed -e '/require(verifyReportImpl/,/require(signerQuote/ s_^_//_' $IMPLDIR/WorkersImpl.sol > WorkersImplSimulation.sol
+sed -i "s/library WorkersImpl /library WorkersImplSimulation /" WorkersImplSimulation.sol
 
 # Check if the existing WorkersImpl-Simulation matches the above substitution
-if ! diff WorkersImpl-Simulation.sol $IMPLDIR/WorkersImpl-Simulation.sol > /dev/null 2>&1; then
+if ! diff WorkersImplSimulation.sol $IMPLDIR/WorkersImplSimulation.sol > /dev/null 2>&1; then
 	if [ $FIX = 1 ]; then
-		mv WorkersImpl-Simulation.sol $IMPLDIR/WorkersImpl-Simulation.sol
-	else		
-		echo "Error: WorkersImpl.sol and WorkersImpl-Simulation.sol differ more than they should."; 
+		mv WorkersImplSimulation.sol $IMPLDIR/WorkersImplSimulation.sol
+	else
+		echo "Error: WorkersImpl.sol and WorkersImplSimulation.sol differ more than they should.";
 		echo "Run this script with --fix to fix the differences automatically."
-		rm -f WorkersImpl-Simulation.sol
+		rm -f WorkersImplSimulation.sol
 		popd > /dev/null 2>&1
 		exit 1;
 	fi
+else
+	rm -f WorkersImplSimulation.sol
+fi
+
+# Replace what needs to be replaced in TaskImpl.sol to support Simulation
+sed -e "s#import { WorkersImpl } from \"./WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./WorkersImplSimulation.sol\";#" $IMPLDIR/TaskImpl.sol > TaskImplSimulation.sol
+sed -i "s/WorkersImpl\./WorkersImplSimulation./g" TaskImplSimulation.sol
+
+# Check if the existing TaskImplSimulation.sol matches the replacement version
+if ! diff TaskImplSimulation.sol $IMPLDIR/TaskImplSimulation.sol > /dev/null 2>&1; then
+	if [ $FIX = 1 ]; then
+		mv TaskImplSimulation.sol $IMPLDIR/TaskImplSimulation.sol
+	else
+		echo "Error: TaskImpl.sol and TaskImplSimulation.sol differ more than they should.";
+		echo "Run this script with --fix to fix the differences automatically."
+		rm -f TaskImplSimulation.sol
+		popd > /dev/null 2>&1
+		exit 1;
+	fi
+else
+	rm -f TaskImplSimulation.sol
+fi
+
+# Replace what needs to be replaced in PrincipalImpl.sol to support Simulation
+sed -e "s#import { WorkersImpl } from \"./WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./WorkersImplSimulation.sol\";#" $IMPLDIR/PrincipalImpl.sol > PrincipalImplSimulation.sol
+sed -i "s/WorkersImpl\./WorkersImplSimulation./g" PrincipalImplSimulation.sol
+
+# Check if the existing PrincipalImplSimulation.sol matches the replacement version
+if ! diff PrincipalImplSimulation.sol $IMPLDIR/PrincipalImplSimulation.sol > /dev/null 2>&1; then
+	if [ $FIX = 1 ]; then
+		mv PrincipalImplSimulation.sol $IMPLDIR/PrincipalImplSimulation.sol
+	else
+		echo "Error: PrincipalImpl.sol and PrincipalImplSimulation.sol differ more than they should.";
+		echo "Run this script with --fix to fix the differences automatically."
+		rm -f PrincipalImplSimulation.sol
+		popd > /dev/null 2>&1
+		exit 1;
+	fi
+else
+	rm -f PrincipalImplSimulation.sol
 fi
 
 # return to the folder where this script was called from

--- a/scripts/checkSimulationContracts.bash
+++ b/scripts/checkSimulationContracts.bash
@@ -55,6 +55,7 @@ fi
 # Replace what needs to be replaced in TaskImpl.sol to support Simulation
 sed -e "s#import { WorkersImpl } from \"./WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./WorkersImplSimulation.sol\";#" $IMPLDIR/TaskImpl.sol > TaskImplSimulation.sol
 sed -i "s/WorkersImpl\./WorkersImplSimulation./g" TaskImplSimulation.sol
+sed -i "s/library TaskImpl /library TaskImplSimulation /" TaskImplSimulation.sol
 
 # Check if the existing TaskImplSimulation.sol matches the replacement version
 if ! diff TaskImplSimulation.sol $IMPLDIR/TaskImplSimulation.sol > /dev/null 2>&1; then
@@ -74,6 +75,7 @@ fi
 # Replace what needs to be replaced in PrincipalImpl.sol to support Simulation
 sed -e "s#import { WorkersImpl } from \"./WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./WorkersImplSimulation.sol\";#" $IMPLDIR/PrincipalImpl.sol > PrincipalImplSimulation.sol
 sed -i "s/WorkersImpl\./WorkersImplSimulation./g" PrincipalImplSimulation.sol
+sed -i "s/library PrincipalImpl /library PrincipalImplSimulation /" PrincipalImplSimulation.sol
 
 # Check if the existing PrincipalImplSimulation.sol matches the replacement version
 if ! diff PrincipalImplSimulation.sol $IMPLDIR/PrincipalImplSimulation.sol > /dev/null 2>&1; then


### PR DESCRIPTION
Follow-up of #41, which could not be fully tested until the Principal Node provided support for Simulation Mode. Now this code had been amended and successfully tested, using the end-to-end integration tests.

- The migrations were not being handled properly because the Simulation versions were colliding with the regular versions and not being really processed.
- Other contracts beyond `Enigma.sol` and `impl/WorkersImpl.sol` have to be modified, namely `impl/TaskImpl.sol` and `PrincipalImpl.sol` as they also depend on a modified version of `impl/WorkersImpl.sol`
- The ` migrations/2_deploy_contracts.js` and `scripts/checkSimulationContracts.bash` have been updated accordingly.

Also modified the Travis CI config so that the unit tests are run twice, one in normal mode, and again in simulation mode.