### PR TITLE
Fix checkSimulationContracts.bash in MacOS

### DIFF
--- a/scripts/checkSimulationContracts.bash
+++ b/scripts/checkSimulationContracts.bash
@@ -15,8 +15,8 @@ IMPLDIR="$CONTRACTSDIR/impl";
 
 # Replace what needs to be replaced in Enigma.sol to support Simulation
 sed -e "s#import { WorkersImpl } from \"./impl/WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./impl/WorkersImplSimulation.sol\";#" $CONTRACTSDIR/Enigma.sol > EnigmaSimulation.sol
-sed -i "s/contract Enigma is/contract EnigmaSimulation is/" EnigmaSimulation.sol
-sed -i "s/WorkersImpl\./WorkersImplSimulation./g" EnigmaSimulation.sol
+sed -e "s/contract Enigma is/contract EnigmaSimulation is/" EnigmaSimulation.sol > EnigmaSimulation.tmp && mv EnigmaSimulation.tmp EnigmaSimulation.sol
+sed -e "s/WorkersImpl\./WorkersImplSimulation./g" EnigmaSimulation.sol > EnigmaSimulation.tmp && mv EnigmaSimulation.tmp EnigmaSimulation.sol
 
 # Check if the existing EnigmaSimulation.sol matches the replacement version
 if ! diff EnigmaSimulation.sol $CONTRACTSDIR/EnigmaSimulation.sol > /dev/null 2>&1; then
@@ -35,7 +35,7 @@ fi
 
 # Comment out a block to support Simulation Mode in WorkersImpl.sol
 sed -e '/require(verifyReportImpl/,/require(signerQuote/ s_^_//_' $IMPLDIR/WorkersImpl.sol > WorkersImplSimulation.sol
-sed -i "s/library WorkersImpl /library WorkersImplSimulation /" WorkersImplSimulation.sol
+sed -e "s/library WorkersImpl /library WorkersImplSimulation /" WorkersImplSimulation.sol > WorkersImplSimulation.tmp && mv WorkersImplSimulation.tmp WorkersImplSimulation.sol
 
 # Check if the existing WorkersImpl-Simulation matches the above substitution
 if ! diff WorkersImplSimulation.sol $IMPLDIR/WorkersImplSimulation.sol > /dev/null 2>&1; then
@@ -54,8 +54,8 @@ fi
 
 # Replace what needs to be replaced in TaskImpl.sol to support Simulation
 sed -e "s#import { WorkersImpl } from \"./WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./WorkersImplSimulation.sol\";#" $IMPLDIR/TaskImpl.sol > TaskImplSimulation.sol
-sed -i "s/WorkersImpl\./WorkersImplSimulation./g" TaskImplSimulation.sol
-sed -i "s/library TaskImpl /library TaskImplSimulation /" TaskImplSimulation.sol
+sed -e "s/WorkersImpl\./WorkersImplSimulation./g" TaskImplSimulation.sol > TaskImplSimulation.tmp && mv TaskImplSimulation.tmp TaskImplSimulation.sol
+sed -e "s/library TaskImpl /library TaskImplSimulation /" TaskImplSimulation.sol > TaskImplSimulation.tmp && mv TaskImplSimulation.tmp TaskImplSimulation.sol
 
 # Check if the existing TaskImplSimulation.sol matches the replacement version
 if ! diff TaskImplSimulation.sol $IMPLDIR/TaskImplSimulation.sol > /dev/null 2>&1; then
@@ -74,8 +74,8 @@ fi
 
 # Replace what needs to be replaced in PrincipalImpl.sol to support Simulation
 sed -e "s#import { WorkersImpl } from \"./WorkersImpl.sol\";#import { WorkersImplSimulation } from \"./WorkersImplSimulation.sol\";#" $IMPLDIR/PrincipalImpl.sol > PrincipalImplSimulation.sol
-sed -i "s/WorkersImpl\./WorkersImplSimulation./g" PrincipalImplSimulation.sol
-sed -i "s/library PrincipalImpl /library PrincipalImplSimulation /" PrincipalImplSimulation.sol
+sed -e "s/WorkersImpl\./WorkersImplSimulation./g" PrincipalImplSimulation.sol > PrincipalImplSimulation.tmp && mv PrincipalImplSimulation.tmp PrincipalImplSimulation.sol
+sed -e "s/library PrincipalImpl /library PrincipalImplSimulation /" PrincipalImplSimulation.sol > PrincipalImplSimulation.tmp && mv PrincipalImplSimulation.tmp PrincipalImplSimulation.sol
 
 # Check if the existing PrincipalImplSimulation.sol matches the replacement version
 if ! diff PrincipalImplSimulation.sol $IMPLDIR/PrincipalImplSimulation.sol > /dev/null 2>&1; then


### PR DESCRIPTION
Bash script uses `-i '' / --in-place ''` option that is not standardized across `sed` implementations in GNU (compatible) and MacOS (not supported). 

This PR changes modification of a file "in place" for writing to a tmp file, and using that to overwrite the original file.