### PR TITLE
TST: increased timeouts for integrationTests

### DIFF
--- a/enigma-js/test/integrationTests/template.10_execute_calculator.js
+++ b/enigma-js/test/integrationTests/template.10_execute_calculator.js
@@ -61,7 +61,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task1 = await enigma.getTaskRecordStatus(task1);
@@ -106,7 +106,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task2 = await enigma.getTaskRecordStatus(task2);

--- a/enigma-js/test/integrationTests/template.10_execute_erc20.js
+++ b/enigma-js/test/integrationTests/template.10_execute_erc20.js
@@ -85,7 +85,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task = await enigma.getTaskRecordStatus(task);

--- a/enigma-js/test/integrationTests/template.10_execute_flipcoin.js
+++ b/enigma-js/test/integrationTests/template.10_execute_flipcoin.js
@@ -58,7 +58,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task = await enigma.getTaskRecordStatus(task);

--- a/enigma-js/test/integrationTests/template.10_execute_millionaire.js
+++ b/enigma-js/test/integrationTests/template.10_execute_millionaire.js
@@ -64,7 +64,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task1 = await enigma.getTaskRecordStatus(task1);
@@ -95,7 +95,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task2 = await enigma.getTaskRecordStatus(task2);
@@ -123,7 +123,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task3 = await enigma.getTaskRecordStatus(task3);

--- a/enigma-js/test/integrationTests/template.10_execute_revert.js
+++ b/enigma-js/test/integrationTests/template.10_execute_revert.js
@@ -6,7 +6,9 @@ import Web3 from 'web3';
 import Enigma from '../../src/Enigma';
 import utils from '../../src/enigma-utils';
 import * as eeConstants from '../../src/emitterConstants';
-import {EnigmaContract, EnigmaTokenContract} from './contractLoader'
+import {EnigmaContract, EnigmaTokenContract} from './contractLoader';
+import * as constants from './testConstants';
+
 
 
 function sleep(ms) {

--- a/enigma-js/test/integrationTests/template.10_execute_revert.js
+++ b/enigma-js/test/integrationTests/template.10_execute_revert.js
@@ -57,7 +57,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });    
+  }, constants.TIMEOUT_COMPUTE);    
 
   it('should get the confirmed task', async () => {
     do {
@@ -67,7 +67,7 @@ describe('Enigma tests', () => {
     } while (task1.ethStatus != 2);
     expect(task1.ethStatus).toEqual(2);
     process.stdout.write('Completed. Final Task Status is '+task1.ethStatus+'\n');
-  }, 10000);
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the result and verify the computation is correct', async () => {
     task1 = await new Promise((resolve, reject) => {
@@ -98,7 +98,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the confirmed task failure', async () => {
     do {
@@ -108,7 +108,7 @@ describe('Enigma tests', () => {
     } while (task2.ethStatus != 4);
     expect(task2.ethStatus).toEqual(4);
     process.stdout.write('Completed. Final Task Status is '+task2.ethStatus+'\n');
-  }, 10000);
+  }, constants.TIMEOUT_COMPUTE);
 
   let task3;
   it('should read the state again, and validate the value is still the initial value, despite the write_state!', async () => {
@@ -121,7 +121,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });    
+  }, constants.TIMEOUT_COMPUTE);    
 
   it('should get the confirmed task', async () => {
     do {
@@ -131,7 +131,7 @@ describe('Enigma tests', () => {
     } while (task3.ethStatus != 2);
     expect(task3.ethStatus).toEqual(2);
     process.stdout.write('Completed. Final Task Status is '+task3.ethStatus+'\n');
-  }, 10000);
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the result and verify the computation is correct', async () => {
     task3 = await new Promise((resolve, reject) => {

--- a/enigma-js/test/integrationTests/template.10_execute_voting.js
+++ b/enigma-js/test/integrationTests/template.10_execute_voting.js
@@ -83,7 +83,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task1 = await enigma.getTaskRecordStatus(task1);
@@ -117,7 +117,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task2 = await enigma.getTaskRecordStatus(task2);
@@ -180,7 +180,7 @@ describe('Enigma tests', () => {
         .on(eeConstants.SEND_TASK_INPUT_RESULT, (result) => resolve(result))
         .on(eeConstants.ERROR, (error) => reject(error));
     });
-  });
+  }, constants.TIMEOUT_COMPUTE);
 
   it('should get the pending task', async () => {
     task3 = await enigma.getTaskRecordStatus(task3);


### PR DESCRIPTION
Adjusting timeouts for integrationTests. With the move from 1 node to 3 nodes, the epoch changes now happen at different times, which causes some timeouts that were not a problem before. Adjusting these accordingly.