### PR TITLE
BUG: fix deploy stage of .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,10 +91,13 @@ steps:
       PASSWORD:
         from_secret: password
     commands:
+      - cd docker-environment
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
       - if [[ ${DRONE_BRANCH} == "master" ]]; then export DOCKER_TAG=latest; else export DOCKER_TAG=develop; fi
-      - docker tag enigmampc/contract:contract_${DRONE_BUILD_NUMBER} enigmampc/contract:$DOCKER_TAG
-      - docker tag enigmampc/client:contract_${DRONE_BUILD_NUMBER} enigmampc/client:$DOCKER_TAG
+      - make clone-contract BRANCH=${DRONE_BRANCH}
+      - make clone-client-solo BRANCH=${DRONE_BRANCH}
+      - make build-contract DOCKER_TAG=$DOCKER_TAG
+      - make build-client DOCKER_TAG=$DOCKER_TAG
       - docker push enigmampc/contract:$DOCKER_TAG
       - docker push enigmampc/client:$DOCKER_TAG
 


### PR DESCRIPTION
At the `deploy` stage, the docker images used for testing are no longer available; so we build them again to be pushed to the DockerHub

And we `cd` into the folder because when a new step in the pipeline starts, we start at the root