### PR TITLE
Added dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+**/node_modules
+build/*
+**/lib
+.git


### PR DESCRIPTION
This file is useful when creating a local "gitclone_contract" docker image based on the local working directory, rather than an actual clone of the repository from git. Without this file, images based on local changes get very big because they include the node_modules directories as well as many build files.