### PR TITLE
BUG: match kovan as substring, instead of exact match

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -94,7 +94,7 @@ async function deployProtocol(deployer, network, accounts) {
   await deployer.deploy(Enigma, TOKEN_ADDRESS, principal, ExchangeRate.address, EPOCH_SIZE, TIMEOUT_THRESHOLD,
       SGX_DEBUG, SGX_MRSIGNER, SGX_ISVSVN);
 
-  if (network != 'kovan') {
+  if (!network.includes('kovan')) {
     await deployer.deploy(Sample);
     await deployer.deploy(VotingETH);
   }
@@ -149,7 +149,7 @@ async function deployProtocol(deployer, network, accounts) {
       }
     });
 
-    if (network != 'kovan') {
+    if (!network.includes('kovan')) {
       fs.writeFile(path.join(homedir, '.enigma', 'votingcontract.txt'), VotingETH.address, 'utf8', function(err) {
         if(err) {
           return console.log(err);


### PR DESCRIPTION
Migration script conditionally deploys some contracts depending on whether we are using `kovan` network or not.

When migrations are run with `--dry-run`, network name is `kovan-fork`. This PR adjusts the conditions so that the output is the same with or without the dry-run by using function `string.includes()` to find a match instead of looking for an exact string match.

```
Migrations dry-run (simulation)
===============================
> Network name:    'kovan-fork'
> Network id:      42
> Block gas limit: 0x989680
```

```
Starting migrations...
======================
> Network name:    'kovan'
> Network id:      42
> Block gas limit: 0x989680
```